### PR TITLE
Return single item from `fromYAML` if single doc

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -18,7 +18,9 @@ rec {
       parsed = map builtins.fromJSON jsonLines;
       nonNull = builtins.filter (v: v != null) parsed;
     in
-    nonNull;
+      if builtins.length nonNull != 1
+      then nonNull
+      else builtins.elemAt nonNull 0;
 
   /* Serialize the object into a yaml file.
   


### PR DESCRIPTION
`fromYAML`'s comment says
https://github.com/farcaller/nix-kube-generators/blob/bba2e70a98ea6693cf755da50c8bb3e3bf1730a0/lib/default.nix#L3-L5
but, because of the nature of `builtins.filter`, single-doc YAML files also turn out to be lists:
```
nix-repl> :lf .
Added 17 variables.

nix-repl> pkgs = import <nixpkgs> {system ="x86_64-linux";}

nix-repl> kubelib = inputs.nix-kube-generators.lib {inherit pkgs;}

nix-repl> parsed = kubelib.fromYAML (builtins.readFile ./releases/svc/sota-slack-spotter/values.yaml)

nix-repl> parsed
[ { ... } ]

nix-repl> builtins.elemAt parsed 0
{ controllers = { ... }; defaultPodOptions = { ... }; persistence = { ... }; service = { ... }; }
```
(I'm still a caveman with the REPL, so tips are always welcome.)

[This](https://git.sr.ht/~goorzhel/kubeflake/commit/1826882c13ebb0c9e4fb0f56e88bb60c64706e74) is how I'm working around it for now, and <details><summary>here's what happens if I don't</summary>

TL;DR: "cannot unmarshal array into Go value of type map[string]interface", i.e., Helm wants a map but got a list.
```
❯ git diff -U0
diff --git a/lib/default.nix b/lib/default.nix
index 296ec35..4c08887 100644
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -2 +2 @@
-  getValues = path: builtins.elemAt (kubelib.fromYAML (builtins.readFile path)) 0;
+  getValues = path: kubelib.fromYAML (builtins.readFile path);

❯ nix build .#releases.svc.sota-slack-spotter
warning: Git tree '/home/ag/src/kubeflake' is dirty
error: builder for '/nix/store/gslp0rfxhvhmz56jc9jva59nzpmh8gc3-helm--nix-store-04als8nj25idiis9xp7jdqz7bpmc6rmp-helm-chart-https-bjw-s.github.io-helm-charts-app-template-2.2.0-svc-sota-slack-spotter.drv' failed with exit code 1;
       last 2 log lines:
       > installing
       > Error: failed to parse /build/.attr-0mh2pszyf8r91rm2w38nmkcykx1v1748birsf1lvn4icddqa3rr8: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type map[string]interface {}
       For full logs, run 'nix log /nix/store/gslp0rfxhvhmz56jc9jva

❯ nix derivation show /nix/store/gslp0rfxhvhmz56jc9jva59nzpmh8gc3-helm--nix-store-04als8nj25idiis9xp7jdqz7bpmc6rmp-helm-chart-https-bjw-s.github.io-helm-charts-app-template-2.2.0-svc-sota-slack-spotter.drv^\* | grep '"helmValues":'
      "helmValues": "[{\"controllers\":{\"main\":{\"containers\":{\"main\":{\"env\":{\"RUST_LOG\":\"debug,rustls=info,ureq=info,hyper=info\"},\"envFrom\":[{\"secretRef\":{\"name\":\"sota-slack-spotter\"}}],\"image\":{\"repository\":\"registry.svc.eureka.lan/sota-slack-spotter\",\"tag\":\"latest\"},\"probes\":{\"liveness\":{\"enabled\":false},\"readiness\":{\"enabled\":false},\"startup\":{\"enabled\":false}}}},\"type\":\"statefulset\"}},\"defaultPodOptions\":{\"annotations\":{\"prometheus.io/port\":\"9000\"}},\"persistence\":{\"cache\":{\"accessMode\":\"ReadWriteOnce\",\"size\":\"50Mi\",\"storageClass\":\"longhorn\",\"type\":\"persistentVolumeClaim\"}},\"service\":{\"main\":{\"enabled\":false}}}]",
```
</details>
