### PR TITLE
Revert "Return single item from `fromYAML` if single doc"

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -18,9 +18,7 @@ rec {
       parsed = map builtins.fromJSON jsonLines;
       nonNull = builtins.filter (v: v != null) parsed;
     in
-      if builtins.length nonNull != 1
-      then nonNull
-      else builtins.elemAt nonNull 0;
+    nonNull;
 
   /* Serialize the object into a yaml file.
   


### PR DESCRIPTION
Reverts farcaller/nix-kube-generators#5

I thought about this for a bit more and I decided I don't agree with this change. The way it was designed originally, fromYAML always returns a list, so you don't need to guess how many objects are in that yaml, it's effectively generic. With this change, you need to special-case documents with a single object.

@Goorzhel I recommend passing the output to `builtins.head` if you're sure there is a single object in that yaml.