### PR TITLE
Make output hash from downloadHelmChart predictable

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -57,7 +57,6 @@ rec {
       OUT_DIR="$TMP/temp-chart-output"
 
       mkdir -p "$OUT_DIR"
-      mkdir $out
 
       ${pkgs.kubernetes-helm}/bin/helm pull \
       --repo "${repo}" \
@@ -66,7 +65,7 @@ rec {
       -d $OUT_DIR \
       --untar
 
-      mv $OUT_DIR/${chart}/* "$out"
+      mv $OUT_DIR/${chart} "$out"
     '';
 
     outputHashMode = "recursive";


### PR DESCRIPTION
When doing `mv $OUT_DIR/${chart}/* "$out"` all dotfiles in the pulled helm chart directory do not get moved with it and many (if not all?) charts contain a `.helmignore` which does not get included in the final derivation's output.

This is not a problem when templating the chart but the hash can't easily be calculated beforehand and requires setting fake hash and reading the expected hash from logs on the failed build.

With this change a prefetch script (`nix-prefetch-helm`?) can be created that does either of the following (with argo-cd as example):

**Manual way** (more fragile to API changes of course)
```bash
REPO="https://argoproj.github.io/argo-helm"
CHART="argo-cd"
VERSION="5.51.4"

# Get tgz file of chart version
TAR_URL=`curl -s "$REPO/index.yaml" | yq ".entries[\"$CHART\"][] | select(.version == \"$VERSION\") | .urls[0]"`
# Calculate hash using `nix-prefetch-url` and convert to sri format using `nix hash`
nix hash to-sri --type sha256 `nix-prefetch-url "$TAR_URL" --type sha256 --unpack`
# Outputs: sha256-LOEJ5mYaHEA0RztDkgM9DGTA0P5eNd0SzSlwJIgpbWY=
```

**Using helm pull**
```bash
REPO="https://argoproj.github.io/argo-helm"
CHART="argo-cd"
VERSION="5.51.4"

DEST=`mktemp -d`

# Use helm to pull chart into tmp
helm pull "$CHART" --repo "$REPO" --version "$VERSION" --destination "$DEST" --untar
# Use `nix hash` to calculate hash
nix hash path --type sha256 --sri "$DEST/$CHART"
# Outputs: sha256-LOEJ5mYaHEA0RztDkgM9DGTA0P5eNd0SzSlwJIgpbWY=

rm -r "$DEST"
```

This will of course be a breaking change and and require anyone using `downloadHelmChart` to update the hashes if it's not already present in their `/nix/store`, but I think the change is worth it in the long run.