### PR TITLE
Remove busybox dependency from fromYAML

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -8,7 +8,7 @@ rec {
       passAsFile = "yaml";
       name = "fromYAML";
       phases = [ "buildPhase" ];
-      buildPhase = "${pkgs.busybox}/bin/cat $yamlPath | ${pkgs.yq}/bin/yq -Ms . > $out";
+      buildPhase = "${pkgs.yq}/bin/yq -Ms . $yamlPath > $out";
     }))
     builtins.readFile
     builtins.fromJSON


### PR DESCRIPTION
There was an issue in arnarg/nixidy#18 where building was broken on aarch64-darwin (and darwin in general I think) which we traced back to `fromYAML` needing busybox which is not available for that system.

This removes the busybox dependency. I already cloned this implementation into nixidy and confirmed it works there: https://github.com/arnarg/nixidy/commit/fc9a71f9afc684028f98efbbd8c9b419385f1e49